### PR TITLE
fix(style.css): ensure footer stays at bottom using flexbox

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,6 +26,9 @@ body {
 	line-height: 1.6;
 	color: midnightblue;
 	background-color: aliceblue;
+	display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
 /* site nav styling */
@@ -381,18 +384,4 @@ footer {
 .content-page {
 	width: 80%;
 	margin: 0 auto;
-}
-html, body {
-  height: 100%;
-  margin: 0;
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-main {
-  flex: 1;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -382,3 +382,17 @@ footer {
 	width: 80%;
 	margin: 0 auto;
 }
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** `#86`

- **Summary:**  
  - 🔨 This PR fixes the issue where the footer appeared in the middle of the page on large desktop screens with short content.  
  - 👀 The footer now consistently sticks to the bottom of the viewport, regardless of content length.  
  - 🗨️ Implemented a flexbox-based layout in `style.css` to achieve a "sticky footer".  

- **Changes:**
  - ✅ Updated global `style.css` with `flexbox` layout rules (`html, body, main, footer`).  
  - ✅ Footer now stays at the bottom even when content is short.  
  - 🔗 Resolves layout bug described in Issue #86.  
  - 📝 No breaking changes.  

## Screenshots / Visual Aids 🔎 <sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub> <details> <summary> Expand ⬇️ </summary> <!-- add GIFs/Screenshots/Videos/Diagrams here --> 

Before:
<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/ead6a600-a428-4eda-8574-ebbfde305d4c" />

After:
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/228a5af4-3513-4ce3-9cbb-23cb607edff2" />


</details>

## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Open `about.html` (or any page with short content).  
   - Step 2: Expand window to full screen.  
   - Step 3: Observe footer position.  

2. **Expected Behavior:**  
   - Footer stays pinned to the bottom of the viewport.  
   - On pages with longer content, footer should move below with scrolling (normal behavior).  

3. **Actual Behavior (before fix):**  
   - Footer floated above the bottom on screens with little content.  

## Checklist ✅
- [x] I have **tested** this PR locally and it works as expected.  
- [x] This PR **resolves an issue** (`Resolves #86`).  
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned.  
- [ ] **Squash commits** and enable **auto-merge** if approved.  
